### PR TITLE
[feat] 학교 페이지 생성 API 기능 구현

### DIFF
--- a/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
+++ b/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
@@ -29,8 +29,12 @@ public enum BaseResponseCode {
     USER_NOT_FOUND("U0001", HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
     ROLE_NOT_FOUND("U0002", HttpStatus.NOT_FOUND, "역할을 찾을 수 없습니다."),
     USER_ALREADY_JOIN("U0003", HttpStatus.NOT_FOUND, "이미 존재하는 이메일입니다."),
-    INVALID_PASSWORD("U0004", HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD("U0004", HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
 
+    // school : SUCCESS 코드와 중복으로 인해 C000X로 지정함
+    NOT_EMPTY_SCHOOL_NAME("C0001", HttpStatus.BAD_REQUEST, "학교명을 입력해주세요,"),
+    NOT_EMPTY_SCHOOL_REGION("C0002", HttpStatus.BAD_REQUEST, "학교 자역을 입력해주세요,"),
+    ALREADY_REGISTERED_SCHOOL("C0003", HttpStatus.BAD_REQUEST, "이미 등록된 학교입니다.");
 
     public final String code;
     public final HttpStatus status;

--- a/src/main/java/com/example/everyminute/school/controller/SchoolController.java
+++ b/src/main/java/com/example/everyminute/school/controller/SchoolController.java
@@ -1,0 +1,41 @@
+package com.example.everyminute.school.controller;
+
+import com.example.everyminute.global.resolver.Account;
+import com.example.everyminute.global.response.ResponseCustom;
+import com.example.everyminute.school.dto.request.RegisterSchoolReq;
+import com.example.everyminute.school.service.SchoolService;
+import com.example.everyminute.user.entity.User;
+import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "학교 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/schools")
+public class SchoolController {
+
+    private final SchoolService schoolService;
+
+    @Operation(summary = "학교 생성", description = "학교 페이지를 생성한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001) 학교 생성 성공"),
+            @ApiResponse(responseCode = "409", description = "(C0003) 이미 등록된 학교입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))
+    })
+    @PostMapping("")
+    public ResponseCustom registerSchoolByAdmin(
+            @Account User user,
+            @RequestBody RegisterSchoolReq registerSchoolReq)
+    {
+        schoolService.registerSchoolByAdmin(user, registerSchoolReq);
+        return ResponseCustom.OK();
+    }
+}

--- a/src/main/java/com/example/everyminute/school/dto/request/RegisterSchoolReq.java
+++ b/src/main/java/com/example/everyminute/school/dto/request/RegisterSchoolReq.java
@@ -1,0 +1,18 @@
+package com.example.everyminute.school.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class RegisterSchoolReq {
+
+    @Schema(type = "String", description = "학교명", example = "명지대학교", required = true)
+    @NotBlank(message = "C0001")
+    private String schoolName;
+
+    @Schema(type = "String", description = "학교 지역", example = "서울", required = true)
+    @NotBlank(message = "C0002")
+    private String region;
+
+}

--- a/src/main/java/com/example/everyminute/school/entity/School.java
+++ b/src/main/java/com/example/everyminute/school/entity/School.java
@@ -2,7 +2,9 @@ package com.example.everyminute.school.entity;
 
 import com.example.everyminute.global.entity.BaseEntity;
 import com.example.everyminute.news.entity.News;
+import com.example.everyminute.school.dto.request.RegisterSchoolReq;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,4 +33,17 @@ public class School extends BaseEntity {
 
     @OneToMany(mappedBy = "school")
     private List<News> newsList = new ArrayList<News>();
+
+    @Builder
+    public School(String name, String region) {
+        this.name = name;
+        this.region = region;
+    }
+
+    public static School of(RegisterSchoolReq registerSchoolReq) {
+        return School.builder()
+                .name(registerSchoolReq.getSchoolName())
+                .region(registerSchoolReq.getRegion())
+                .build();
+    }
 }

--- a/src/main/java/com/example/everyminute/school/repository/SchoolRepository.java
+++ b/src/main/java/com/example/everyminute/school/repository/SchoolRepository.java
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface SchoolRepository extends JpaRepository<School, Long> {
 
+    Boolean existsByNameAndRegionAndIsEnable(String name, String region, Boolean isEnable);
+
 }

--- a/src/main/java/com/example/everyminute/school/service/SchoolService.java
+++ b/src/main/java/com/example/everyminute/school/service/SchoolService.java
@@ -1,0 +1,30 @@
+package com.example.everyminute.school.service;
+
+import com.example.everyminute.global.exception.BaseException;
+import com.example.everyminute.global.exception.BaseResponseCode;
+import com.example.everyminute.school.dto.request.RegisterSchoolReq;
+import com.example.everyminute.school.entity.School;
+import com.example.everyminute.school.repository.SchoolRepository;
+import com.example.everyminute.user.entity.Role;
+import com.example.everyminute.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SchoolService {
+
+    private final SchoolRepository schoolRepository;
+
+    @Transactional
+    public void registerSchoolByAdmin(User user, RegisterSchoolReq registerSchoolReq) {
+        if(!user.getRole().equals(Role.ADMIN)) throw new BaseException(BaseResponseCode.NO_AUTHENTICATION);
+
+        Boolean isRegister = schoolRepository.existsByNameAndRegionAndIsEnable(registerSchoolReq.getSchoolName(), registerSchoolReq.getRegion(), true);
+        if(isRegister) throw new BaseException(BaseResponseCode.ALREADY_REGISTERED_SCHOOL);
+
+        schoolRepository.save(School.of(registerSchoolReq));
+    }
+}

--- a/src/main/java/com/example/everyminute/user/entity/User.java
+++ b/src/main/java/com/example/everyminute/user/entity/User.java
@@ -43,7 +43,7 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
-    public static User toEntity(JoinReq joinReq) {
+    public static User of(JoinReq joinReq) {
         return User.builder()
                 .name(joinReq.getName())
                 .email(joinReq.getEmail())

--- a/src/main/java/com/example/everyminute/user/service/UserService.java
+++ b/src/main/java/com/example/everyminute/user/service/UserService.java
@@ -27,7 +27,7 @@ public class UserService {
     public void join(JoinReq joinReq) {
         if(userRepository.existsByEmailAndIsEnable(joinReq.getEmail(), true)) throw new BaseException(BaseResponseCode.USER_ALREADY_JOIN);
         joinReq.setPassword(passwordEncoder.encode(joinReq.getPassword()));
-        userRepository.save(User.toEntity(joinReq));
+        userRepository.save(User.of(joinReq));
     }
 
     // 로그인


### PR DESCRIPTION
## 작업 내용
- 학교 페이지 생성 API 기능 구현입니다.
- 학교명과 지역이 동시에 중복 시 예외 발생하도록 처리했습니다.
- 학교명 중복 허용 (명지대학교-용인, 명지대학교-서울)
- 학교 페이지 생성은 관리자 권한입니다.
## 스크린샷
![스크린샷 2024-03-28 오후 9 50 03](https://github.com/dangnak2/EveryMinute_Server/assets/80161984/1683a653-c9fb-437f-94ac-937409bf9e29)
![스크린샷 2024-03-28 오후 9 50 18](https://github.com/dangnak2/EveryMinute_Server/assets/80161984/cbc15c2d-cc2e-4569-bad5-227daf11f092)
![스크린샷 2024-03-28 오후 9 50 55](https://github.com/dangnak2/EveryMinute_Server/assets/80161984/5a9b9657-330c-4f05-83e3-c8d458c9e6af)

## 💬 기타 사항
- x

Closes #8 