### PR TITLE
[feat] 학교페이지 소식 API 기능구현

### DIFF
--- a/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
+++ b/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
@@ -34,7 +34,13 @@ public enum BaseResponseCode {
     // school : SUCCESS 코드와 중복으로 인해 C000X로 지정함
     NOT_EMPTY_SCHOOL_NAME("C0001", HttpStatus.BAD_REQUEST, "학교명을 입력해주세요,"),
     NOT_EMPTY_SCHOOL_REGION("C0002", HttpStatus.BAD_REQUEST, "학교 자역을 입력해주세요,"),
-    ALREADY_REGISTERED_SCHOOL("C0003", HttpStatus.BAD_REQUEST, "이미 등록된 학교입니다.");
+    ALREADY_REGISTERED_SCHOOL("C0003", HttpStatus.BAD_REQUEST, "이미 등록된 학교입니다."),
+    SCHOOL_NOT_FOUNT("C0004", HttpStatus.NOT_FOUND, "존재하지 않는 학교입니다."),
+
+    // news
+    INVALID_NEWS_TITLE("N0001", HttpStatus.BAD_REQUEST, "이미 존재하는 소식 제목입니다."),
+    NOT_EMPTY_NEWS_TITLE("N0002", HttpStatus.BAD_REQUEST, "소식 제목을 입력해주세요."),
+    NOT_EMPTY_NEWS_CONTENT("N0003", HttpStatus.BAD_REQUEST, "소식 내용을 입력해주세요.");
 
     public final String code;
     public final HttpStatus status;

--- a/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
+++ b/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
@@ -40,7 +40,8 @@ public enum BaseResponseCode {
     // news
     INVALID_NEWS_TITLE("N0001", HttpStatus.BAD_REQUEST, "이미 존재하는 소식 제목입니다."),
     NOT_EMPTY_NEWS_TITLE("N0002", HttpStatus.BAD_REQUEST, "소식 제목을 입력해주세요."),
-    NOT_EMPTY_NEWS_CONTENT("N0003", HttpStatus.BAD_REQUEST, "소식 내용을 입력해주세요.");
+    NOT_EMPTY_NEWS_CONTENT("N0003", HttpStatus.BAD_REQUEST, "소식 내용을 입력해주세요."),
+    NEWS_NOT_FOUND("N0004", HttpStatus.NOT_FOUND, "존재하지 않는 소식입니다.");
 
     public final String code;
     public final HttpStatus status;

--- a/src/main/java/com/example/everyminute/news/controller/NewsController.java
+++ b/src/main/java/com/example/everyminute/news/controller/NewsController.java
@@ -1,0 +1,30 @@
+package com.example.everyminute.news.controller;
+
+import com.example.everyminute.global.resolver.Account;
+import com.example.everyminute.global.response.ResponseCustom;
+import com.example.everyminute.news.dto.request.PostNewsReq;
+import com.example.everyminute.news.service.NewsService;
+import com.example.everyminute.user.entity.User;
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@Api(tags = "학교 소식 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/news")
+public class NewsController {
+
+    private final NewsService newsService;
+
+    // 소식 작성
+    @PostMapping("/{schoolId}")
+    public ResponseCustom postNewsByAdmin(
+            @Account User user,
+            @PathVariable Long schoolId,
+            @RequestBody PostNewsReq postNewsReq)
+    {
+        newsService.postNewsByAdmin(user, schoolId, postNewsReq);
+        return ResponseCustom.OK();
+    }
+}

--- a/src/main/java/com/example/everyminute/news/controller/NewsController.java
+++ b/src/main/java/com/example/everyminute/news/controller/NewsController.java
@@ -3,6 +3,7 @@ package com.example.everyminute.news.controller;
 import com.example.everyminute.global.resolver.Account;
 import com.example.everyminute.global.response.ResponseCustom;
 import com.example.everyminute.news.dto.request.PostNewsReq;
+import com.example.everyminute.news.dto.request.UpdateNewsReq;
 import com.example.everyminute.news.service.NewsService;
 import com.example.everyminute.user.entity.User;
 import io.swagger.annotations.Api;
@@ -38,4 +39,15 @@ public class NewsController {
         return ResponseCustom.OK();
     }
 
+    // 소식 수정
+    @PatchMapping("/{newsId}")
+    public ResponseCustom updateNewsByAdmin(
+           @Account User user,
+           @PathVariable Long newsId,
+           @RequestBody UpdateNewsReq updateNewsReq
+    )
+    {
+        newsService.updateNewsByAdmin(user, newsId, updateNewsReq);
+        return ResponseCustom.OK();
+    }
 }

--- a/src/main/java/com/example/everyminute/news/controller/NewsController.java
+++ b/src/main/java/com/example/everyminute/news/controller/NewsController.java
@@ -27,4 +27,15 @@ public class NewsController {
         newsService.postNewsByAdmin(user, schoolId, postNewsReq);
         return ResponseCustom.OK();
     }
+
+    // 소식 삭제
+    @DeleteMapping("/{newsId}")
+    public ResponseCustom removeNewsByAdmin(
+            @Account User user,
+            @PathVariable Long newsId)
+    {
+        newsService.removeNewsByAdmin(user, newsId);
+        return ResponseCustom.OK();
+    }
+
 }

--- a/src/main/java/com/example/everyminute/news/dto/request/PostNewsReq.java
+++ b/src/main/java/com/example/everyminute/news/dto/request/PostNewsReq.java
@@ -1,0 +1,18 @@
+package com.example.everyminute.news.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class PostNewsReq {
+
+    @Schema(type = "String", description = "소식 제목", example = "명지대학교 공지 1", required = true)
+    @NotNull(message = "N0002")
+    private String title;
+
+    @Schema(type = "String", description = "소식 내용", example = "공지 1입니다.", required = true)
+    @NotNull(message = "N0003")
+    private String contents;
+}

--- a/src/main/java/com/example/everyminute/news/dto/request/UpdateNewsReq.java
+++ b/src/main/java/com/example/everyminute/news/dto/request/UpdateNewsReq.java
@@ -1,0 +1,18 @@
+package com.example.everyminute.news.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+public class UpdateNewsReq {
+
+    @Schema(type = "String", description = "수정 할 제목", example = "명지대학교 공지 1(수정됨)", required = true)
+    @NotNull(message = "N0002")
+    private String title;
+
+    @Schema(type = "String", description = "수정 할 내용", example = "공지 1입니다.(수정됨)", required = true)
+    @NotNull(message = "N0003")
+    private String contents;
+}

--- a/src/main/java/com/example/everyminute/news/entity/News.java
+++ b/src/main/java/com/example/everyminute/news/entity/News.java
@@ -59,4 +59,8 @@ public class News extends BaseEntity {
                 .user(user)
                 .build();
     }
+
+    public void remove() {
+        this.setIsEnable(false);
+    }
 }

--- a/src/main/java/com/example/everyminute/news/entity/News.java
+++ b/src/main/java/com/example/everyminute/news/entity/News.java
@@ -35,14 +35,6 @@ public class News extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-//    @Builder
-//    public News(String title, String contents, School school, User user) {
-//        this.title = title;
-//        this.contents = contents;
-//        this.school = school;
-//        this.user = user;
-//    }
-
     @Builder
     public News(@NonNull String title, String contents, School school, User user) {
         this.title = title;
@@ -62,5 +54,10 @@ public class News extends BaseEntity {
 
     public void remove() {
         this.setIsEnable(false);
+    }
+
+    public void update(String title, String contents) {
+        this.title = title;
+        this.contents = contents;
     }
 }

--- a/src/main/java/com/example/everyminute/news/entity/News.java
+++ b/src/main/java/com/example/everyminute/news/entity/News.java
@@ -1,13 +1,13 @@
 package com.example.everyminute.news.entity;
 
 import com.example.everyminute.global.entity.BaseEntity;
+import com.example.everyminute.news.dto.request.PostNewsReq;
 import com.example.everyminute.school.entity.School;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.NonNull;
+import com.example.everyminute.user.entity.User;
+import lombok.*;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 @Entity
@@ -23,10 +23,40 @@ public class News extends BaseEntity {
     @Size(max = 70)
     private String title;
 
+    @NotNull
     @Column(columnDefinition="TEXT")
     private String contents;
 
     @ManyToOne
     @JoinColumn(name = "school_Id")
     private School school;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+//    @Builder
+//    public News(String title, String contents, School school, User user) {
+//        this.title = title;
+//        this.contents = contents;
+//        this.school = school;
+//        this.user = user;
+//    }
+
+    @Builder
+    public News(@NonNull String title, String contents, School school, User user) {
+        this.title = title;
+        this.contents = contents;
+        this.school = school;
+        this.user = user;
+    }
+
+    public static News of(PostNewsReq postNewsReq, School school, User user) {
+        return News.builder()
+                .title(postNewsReq.getTitle())
+                .contents(postNewsReq.getContents())
+                .school(school)
+                .user(user)
+                .build();
+    }
 }

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepository.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
+
+    Boolean existsByTitleAndIsEnable(String title, Boolean isEnable);
 }

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepository.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepository.java
@@ -4,8 +4,12 @@ import com.example.everyminute.news.entity.News;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface NewsRepository extends JpaRepository<News, Long> {
 
     Boolean existsByTitleAndIsEnable(String title, Boolean isEnable);
+
+    Optional<News> findByNewsIdAndIsEnable(Long newsId, Boolean isEnable);
 }

--- a/src/main/java/com/example/everyminute/news/service/NewsService.java
+++ b/src/main/java/com/example/everyminute/news/service/NewsService.java
@@ -34,6 +34,16 @@ public class NewsService {
         school.addNews(newsRepository.save(News.of(postNewsReq, school, user)));
     }
 
+    @Transactional
+    public void removeNewsByAdmin(User user, Long newsId) {
+        checkAdminRole(user);
+        News news = newsRepository.findByNewsIdAndIsEnable(newsId, true).orElseThrow(() -> new BaseException(BaseResponseCode.NEWS_NOT_FOUND));
+
+        // 양방향 연관관계 해제 후 News 삭제
+        news.getSchool().removeNews(news);
+        news.remove();
+    }
+
     private static void checkAdminRole(User user) {
         if (!user.checkRole(Role.ADMIN)) throw new BaseException(BaseResponseCode.NO_AUTHENTICATION);
     }

--- a/src/main/java/com/example/everyminute/news/service/NewsService.java
+++ b/src/main/java/com/example/everyminute/news/service/NewsService.java
@@ -1,0 +1,40 @@
+package com.example.everyminute.news.service;
+
+import com.example.everyminute.global.exception.BaseException;
+import com.example.everyminute.global.exception.BaseResponseCode;
+import com.example.everyminute.news.dto.request.PostNewsReq;
+import com.example.everyminute.news.entity.News;
+import com.example.everyminute.news.repository.NewsRepository;
+import com.example.everyminute.school.entity.School;
+import com.example.everyminute.school.repository.SchoolRepository;
+import com.example.everyminute.user.entity.Role;
+import com.example.everyminute.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NewsService {
+
+    private final NewsRepository newsRepository;
+    private final SchoolRepository schoolRepository;
+
+    @Transactional
+    public void postNewsByAdmin(User user, Long schoolId, PostNewsReq postNewsReq) {
+        checkAdminRole(user);
+        School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
+
+        // 소식 제목이 겹칠 경우 예외처리 (제목은 중복되지 않는다.)
+        if (newsRepository.existsByTitleAndIsEnable(postNewsReq.getTitle(), true))
+            throw new BaseException(BaseResponseCode.INVALID_NEWS_TITLE);
+
+        // 소식 저장 후 학교 엔티티 양방향 연관관계 저장
+        school.addNews(newsRepository.save(News.of(postNewsReq, school, user)));
+    }
+
+    private static void checkAdminRole(User user) {
+        if (!user.checkRole(Role.ADMIN)) throw new BaseException(BaseResponseCode.NO_AUTHENTICATION);
+    }
+}

--- a/src/main/java/com/example/everyminute/news/service/NewsService.java
+++ b/src/main/java/com/example/everyminute/news/service/NewsService.java
@@ -3,6 +3,7 @@ package com.example.everyminute.news.service;
 import com.example.everyminute.global.exception.BaseException;
 import com.example.everyminute.global.exception.BaseResponseCode;
 import com.example.everyminute.news.dto.request.PostNewsReq;
+import com.example.everyminute.news.dto.request.UpdateNewsReq;
 import com.example.everyminute.news.entity.News;
 import com.example.everyminute.news.repository.NewsRepository;
 import com.example.everyminute.school.entity.School;
@@ -42,6 +43,13 @@ public class NewsService {
         // 양방향 연관관계 해제 후 News 삭제
         news.getSchool().removeNews(news);
         news.remove();
+    }
+
+    @Transactional
+    public void updateNewsByAdmin(User user, Long newsId, UpdateNewsReq updateNewsReq) {
+        checkAdminRole(user);
+        News news = newsRepository.findByNewsIdAndIsEnable(newsId, true).orElseThrow(() -> new BaseException(BaseResponseCode.NEWS_NOT_FOUND));
+        news.update(updateNewsReq.getTitle(), updateNewsReq.getContents());
     }
 
     private static void checkAdminRole(User user) {

--- a/src/main/java/com/example/everyminute/school/entity/School.java
+++ b/src/main/java/com/example/everyminute/school/entity/School.java
@@ -50,4 +50,8 @@ public class School extends BaseEntity {
     public void addNews(News news) {
         this.newsList.add(news);
     }
+
+    public void removeNews(News news) {
+        this.newsList.remove(news);
+    }
 }

--- a/src/main/java/com/example/everyminute/school/entity/School.java
+++ b/src/main/java/com/example/everyminute/school/entity/School.java
@@ -46,4 +46,8 @@ public class School extends BaseEntity {
                 .region(registerSchoolReq.getRegion())
                 .build();
     }
+
+    public void addNews(News news) {
+        this.newsList.add(news);
+    }
 }

--- a/src/main/java/com/example/everyminute/school/repository/SchoolRepository.java
+++ b/src/main/java/com/example/everyminute/school/repository/SchoolRepository.java
@@ -4,9 +4,12 @@ import com.example.everyminute.school.entity.School;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SchoolRepository extends JpaRepository<School, Long> {
 
     Boolean existsByNameAndRegionAndIsEnable(String name, String region, Boolean isEnable);
 
+    Optional<School> findBySchoolIdAndIsEnable(Long schoolId, Boolean isEnable);
 }

--- a/src/main/java/com/example/everyminute/user/entity/User.java
+++ b/src/main/java/com/example/everyminute/user/entity/User.java
@@ -51,4 +51,8 @@ public class User extends BaseEntity {
                 .role(Role.getRoleByName(joinReq.getRole()))
                 .build();
     }
+
+    public boolean checkRole(Role role) {
+        return this.role == role;
+    }
 }


### PR DESCRIPTION
## 작업 내용
0. 소식 등록, 수정, 삭제 API는 관리자 권한입니다.
1. 소식 등록 API
  - 소식 제목이 중복될 경우 예외처리 발생합니다. (제목은 중복되지 않는다.)
  - 소식(News entity) 저장 후 School과 양방향 연관관계를 저장합니다.
2. 소식 수정 API
  - 소식 수정에 필요한 request는 NotNull 처리했습니다.
3. 소식 삭제 API
  - 소식 삭제는 RDB hard delete가 아닌 soft delete로 구현했습니다.
  - 삭제와 동시에 해당 데이터는 학교와 연관 관계를 삭제합니다.
## 스크린샷
![스크린샷 2024-03-29 오전 12 20 44](https://github.com/dangnak2/EveryMinute_Server/assets/80161984/2204af29-0603-48cc-9bdc-1dac876bb577)
![스크린샷 2024-03-29 오전 12 19 38](https://github.com/dangnak2/EveryMinute_Server/assets/80161984/71585e82-c9fb-4187-addd-fb58ee835794)
![스크린샷 2024-03-29 오전 12 19 58](https://github.com/dangnak2/EveryMinute_Server/assets/80161984/cb1c79a4-7a46-4fff-9065-30de87db9224)

## 💬 기타 사항
- x

Closes #10 