### PR TITLE
[feat] 학교 페이지 구독 API 기능구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,8 @@
 buildscript {
+	// QueryDSL
+	ext {
+		queryDslVersion = "5.0.0"
+	}
 	repositories {
 		mavenLocal()
 		maven { url 'https://maven.aliyun.com/repository/google/' }
@@ -15,24 +19,16 @@ buildscript {
 }
 
 plugins {
-//	id 'java'
-//	id 'org.springframework.boot' version '3.2.4'
-//	id 'io.spring.dependency-management' version '1.1.4'
 	id 'java'
 	id 'org.springframework.boot' version '2.7.14'
 	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+	// queryDSL
+	id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
 group = 'jpabook '
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
-
-//group = 'com.example'
-//version = '0.0.1-SNAPSHOT'
-//
-//java {
-//	sourceCompatibility = '17'
-//}
 
 configurations {
 	compileOnly {
@@ -69,8 +65,33 @@ dependencies {
 
 	// spring security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// QueryDSL
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+//querydsl 추가
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
+}
+configurations {
+	compileOnly {
+		extendsFrom annotationProcessor
+	}
+	querydsl.extendsFrom compileClasspath
 }

--- a/src/main/java/com/example/everyminute/global/config/QuerydslConfig.java
+++ b/src/main/java/com/example/everyminute/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.example.everyminute.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import javax.persistence.EntityManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory() {
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
+++ b/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
@@ -41,7 +41,10 @@ public enum BaseResponseCode {
     INVALID_NEWS_TITLE("N0001", HttpStatus.BAD_REQUEST, "이미 존재하는 소식 제목입니다."),
     NOT_EMPTY_NEWS_TITLE("N0002", HttpStatus.BAD_REQUEST, "소식 제목을 입력해주세요."),
     NOT_EMPTY_NEWS_CONTENT("N0003", HttpStatus.BAD_REQUEST, "소식 내용을 입력해주세요."),
-    NEWS_NOT_FOUND("N0004", HttpStatus.NOT_FOUND, "존재하지 않는 소식입니다.");
+    NEWS_NOT_FOUND("N0004", HttpStatus.NOT_FOUND, "존재하지 않는 소식입니다."),
+
+    // subscribe : SUCCESS, USER 코드와 중복으로 인해 B000X로 지정함
+    SUBSCRIBE_NOT_FOUND("B0001", HttpStatus.NOT_FOUND, "존재하지 않는 구독 내역입니다.");
 
     public final String code;
     public final HttpStatus status;

--- a/src/main/java/com/example/everyminute/global/utils/DateTimeUtil.java
+++ b/src/main/java/com/example/everyminute/global/utils/DateTimeUtil.java
@@ -1,0 +1,74 @@
+package com.example.everyminute.global.utils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import static com.example.everyminute.global.Constants.*;
+
+public class DateTimeUtil {
+
+    // localDate + localTime => string(YYYY-MM-DD HH:MM)
+    public static String dateAndTimeToString(LocalDate date, LocalTime time) {
+        return localDateAndTimeToLocalDateTime(date, time).format(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN));
+    }
+
+    // localDate => string(YYYY-MM-DD)
+    public static String dateToString(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern(DATE_PATTERN));
+    }
+
+    // localTime => string(HH:MM)
+    public static String timeToString(LocalTime time) {
+        return time.format(DateTimeFormatter.ofPattern(TIME_PATTERN));
+    }
+
+    // localDateTime => string(YYYY-MM-DD HH:MM)
+    public static String dateTimeToString(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(DATE_TIME_PATTERN));
+    }
+
+    // localDateTime => Null / string(YYYY-MM-DD HH:MM)
+    public static String dateTimeToStringNullable(LocalDateTime localDateTime) {
+        return localDateTime == null ? null : dateTimeToString(localDateTime);
+    }
+
+    // string(YYYY-MM) -> localDate
+    public static LocalDate stringToLocalDate(String stringDate) {
+        return LocalDate.parse(stringDate, DateTimeFormatter.ISO_DATE);
+    }
+
+    public static LocalTime stringToLocalTime(String stringDate) {
+        return LocalTime.parse(stringDate, DateTimeFormatter.ISO_TIME);
+    }
+
+    // string(YYYY-MM) -> localDate (해당 월의 첫 날)
+    public static LocalDate stringToFirstLocalDate(String stringDate) {
+        return stringToLocalDate(stringDate + "-01");
+    }
+
+    // localDate and Local Time -> localDateTime
+    public static LocalDateTime localDateAndTimeToLocalDateTime(LocalDate localDate, LocalTime localTime){
+        return LocalDateTime.of(localDate, localTime);
+    }
+
+    // localDateTime -> LocalDate
+    public static LocalDate dateTimeToDate(LocalDateTime localDateTime) {
+        return localDateTime.toLocalDate();
+    }
+
+    // localDateTime -> LocalTime
+    public static LocalTime dateTimeToTime(LocalDateTime localDateTime) {
+        return localDateTime.toLocalTime();
+    }
+
+    // localDateTime -> localDate + 00:00
+    public static LocalDateTime getMidNightDateTime(LocalDateTime localDateTime) {
+        return LocalDateTime.of(localDateTime.toLocalDate(), LocalTime.MIN);
+    }
+
+    // localDateTime => string(HH:MM)
+    public static String dateTimeToStringTime(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern(TIME_PATTERN));
+    }
+}

--- a/src/main/java/com/example/everyminute/news/controller/NewsController.java
+++ b/src/main/java/com/example/everyminute/news/controller/NewsController.java
@@ -4,10 +4,14 @@ import com.example.everyminute.global.resolver.Account;
 import com.example.everyminute.global.response.ResponseCustom;
 import com.example.everyminute.news.dto.request.PostNewsReq;
 import com.example.everyminute.news.dto.request.UpdateNewsReq;
+import com.example.everyminute.news.dto.response.SchoolNewsRes;
 import com.example.everyminute.news.service.NewsService;
 import com.example.everyminute.user.entity.User;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @Api(tags = "학교 소식 API")
@@ -49,5 +53,14 @@ public class NewsController {
     {
         newsService.updateNewsByAdmin(user, newsId, updateNewsReq);
         return ResponseCustom.OK();
+    }
+
+    // 학교 페이지별 소식
+    @GetMapping("/{schoolId}")
+    public ResponseCustom<Page<SchoolNewsRes>> getSchoolNews(
+            @PathVariable Long schoolId,
+            @PageableDefault(size = 20) Pageable pageable)
+    {
+        return ResponseCustom.OK(newsService.getSchoolNews(schoolId, pageable));
     }
 }

--- a/src/main/java/com/example/everyminute/news/dto/response/SchoolNewsRes.java
+++ b/src/main/java/com/example/everyminute/news/dto/response/SchoolNewsRes.java
@@ -1,0 +1,31 @@
+package com.example.everyminute.news.dto.response;
+
+import com.example.everyminute.global.utils.DateTimeUtil;
+import com.example.everyminute.news.entity.News;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SchoolNewsRes {
+
+    @Schema(type = "String", description = "소식 제목", example = "명지대학교 공지1")
+    private String title;
+    @Schema(type = "String", description = "소식 내용", example = "명지대학교 공지1입니다.")
+    private String contents;
+    @Schema(type = "String", description = "작성자", example = "김민기")
+    private String  writer;
+    @Schema(type = "String", description = "작성일시", example = "2024-03-29 12:00")
+    private String createAt;
+
+    public static SchoolNewsRes toDto(News news) {
+        return SchoolNewsRes.builder()
+                .title(news.getTitle())
+                .contents(news.getContents())
+                .writer(news.getUser().getName())
+                .createAt(DateTimeUtil.dateTimeToString(news.getCreatedAt()))
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/everyminute/news/repository/NewsCustom.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsCustom.java
@@ -1,0 +1,10 @@
+package com.example.everyminute.news.repository;
+
+import com.example.everyminute.news.dto.response.SchoolNewsRes;
+import com.example.everyminute.school.entity.School;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface NewsCustom {
+    Page<SchoolNewsRes> getSchoolNews(School school, Pageable pageable);
+}

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepository.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepository.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface NewsRepository extends JpaRepository<News, Long> {
+public interface NewsRepository extends JpaRepository<News, Long>, NewsCustom {
 
     Boolean existsByTitleAndIsEnable(String title, Boolean isEnable);
 

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
@@ -1,0 +1,38 @@
+package com.example.everyminute.news.repository;
+
+import com.example.everyminute.news.dto.response.SchoolNewsRes;
+import com.example.everyminute.news.entity.News;
+import com.example.everyminute.news.entity.QNews;
+import com.example.everyminute.school.entity.School;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.everyminute.news.entity.QNews.news;
+
+
+@RequiredArgsConstructor
+public class NewsRepositoryImpl implements NewsCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<SchoolNewsRes> getSchoolNews(School school, Pageable pageable) {
+        List<News> schoolNews = jpaQueryFactory.selectFrom(news)
+                .where(news.school.eq(school)
+                        .and(news.isEnable.eq(true)))
+                .fetch();
+
+        List<SchoolNewsRes> res = schoolNews.stream()
+                .map(SchoolNewsRes::toDto).collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), res.size());
+        return new PageImpl<>(res.subList(start, end), pageable, res.size());
+    }
+}

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
@@ -26,6 +26,7 @@ public class NewsRepositoryImpl implements NewsCustom{
         List<News> schoolNews = jpaQueryFactory.selectFrom(news)
                 .where(news.school.eq(school)
                         .and(news.isEnable.eq(true)))
+                .orderBy(news.createdAt.desc())
                 .fetch();
 
         List<SchoolNewsRes> res = schoolNews.stream()

--- a/src/main/java/com/example/everyminute/news/service/NewsService.java
+++ b/src/main/java/com/example/everyminute/news/service/NewsService.java
@@ -4,6 +4,7 @@ import com.example.everyminute.global.exception.BaseException;
 import com.example.everyminute.global.exception.BaseResponseCode;
 import com.example.everyminute.news.dto.request.PostNewsReq;
 import com.example.everyminute.news.dto.request.UpdateNewsReq;
+import com.example.everyminute.news.dto.response.SchoolNewsRes;
 import com.example.everyminute.news.entity.News;
 import com.example.everyminute.news.repository.NewsRepository;
 import com.example.everyminute.school.entity.School;
@@ -11,6 +12,8 @@ import com.example.everyminute.school.repository.SchoolRepository;
 import com.example.everyminute.user.entity.Role;
 import com.example.everyminute.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,5 +57,10 @@ public class NewsService {
 
     private static void checkAdminRole(User user) {
         if (!user.checkRole(Role.ADMIN)) throw new BaseException(BaseResponseCode.NO_AUTHENTICATION);
+    }
+
+    public Page<SchoolNewsRes> getSchoolNews(Long schoolId, Pageable pageable) {
+        School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
+        return newsRepository.getSchoolNews(school, pageable);
     }
 }

--- a/src/main/java/com/example/everyminute/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/example/everyminute/subscribe/controller/SubscribeController.java
@@ -2,10 +2,19 @@ package com.example.everyminute.subscribe.controller;
 
 import com.example.everyminute.global.resolver.Account;
 import com.example.everyminute.global.response.ResponseCustom;
+import com.example.everyminute.subscribe.dto.response.GetSubscriptionsRes;
 import com.example.everyminute.subscribe.service.SubscribeService;
 import com.example.everyminute.user.entity.User;
 import io.swagger.annotations.Api;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @Api(tags = "구독 API")
@@ -17,22 +26,44 @@ public class SubscribeController {
     private final SubscribeService subscribeService;
 
     // 학교 구독
+    @Operation(summary = "학교 구독", description = "학교를 페이지를 구독한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001) 학교 구독 성공"),
+            @ApiResponse(responseCode = "409", description = "(C0004) 존재하지 않는 학교입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))
+    })
     @PostMapping("/{schoolId}")
     public ResponseCustom subscribe(
             @Account User user,
-            @PathVariable Long schoolId)
-    {
+            @PathVariable Long schoolId) {
         subscribeService.subscribeSchool(user, schoolId);
         return ResponseCustom.OK();
     }
 
     // 학교 구독 취소
+    @Operation(summary = "학교 구독 취소", description = "학교 페이지 구독을 취소한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001) 학교 구독 취소 성공"),
+            @ApiResponse(responseCode = "409", description = "(C0004) 존재하지 않는 학교입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class))),
+            @ApiResponse(responseCode = "409", description = "(B0001) 존재하지 않는 구독 내역입니다.", content = @Content(schema = @Schema(implementation = ResponseCustom.class)))
+    })
     @DeleteMapping("/{schoolId}")
     public ResponseCustom cancel(
             @Account User user,
-            @PathVariable Long schoolId)
-    {
+            @PathVariable Long schoolId) {
         subscribeService.cancel(user, schoolId);
         return ResponseCustom.OK();
+    }
+
+    // 학교 구독 목록 조회
+    @Operation(summary = "학교 구독 목록 조회", description = "학교 구독 목록을 조회한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "(S0001) 구독 목록 조회 성공"),
+    })
+    @GetMapping("")
+    public ResponseCustom<Page<GetSubscriptionsRes>> getSubscriptions(
+            @Account User user,
+            @PageableDefault(size = 20) Pageable pageable)
+    {
+        return ResponseCustom.OK(subscribeService.getSubscriptions(user, pageable));
     }
 }

--- a/src/main/java/com/example/everyminute/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/example/everyminute/subscribe/controller/SubscribeController.java
@@ -1,0 +1,31 @@
+package com.example.everyminute.subscribe.controller;
+
+import com.example.everyminute.global.resolver.Account;
+import com.example.everyminute.global.response.ResponseCustom;
+import com.example.everyminute.subscribe.service.SubscribeService;
+import com.example.everyminute.user.entity.User;
+import io.swagger.annotations.Api;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "구독 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/subscribes")
+public class SubscribeController {
+
+    private final SubscribeService subscribeService;
+
+    // 학교 구독
+    @PostMapping("/{schoolId}")
+    public ResponseCustom subscribeSchool(
+            @Account User user,
+            @PathVariable Long schoolId)
+    {
+        subscribeService.subscribeSchool(user, schoolId);
+        return ResponseCustom.OK();
+    }
+}

--- a/src/main/java/com/example/everyminute/subscribe/controller/SubscribeController.java
+++ b/src/main/java/com/example/everyminute/subscribe/controller/SubscribeController.java
@@ -6,10 +6,7 @@ import com.example.everyminute.subscribe.service.SubscribeService;
 import com.example.everyminute.user.entity.User;
 import io.swagger.annotations.Api;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Api(tags = "구독 API")
 @RestController
@@ -21,11 +18,21 @@ public class SubscribeController {
 
     // 학교 구독
     @PostMapping("/{schoolId}")
-    public ResponseCustom subscribeSchool(
+    public ResponseCustom subscribe(
             @Account User user,
             @PathVariable Long schoolId)
     {
         subscribeService.subscribeSchool(user, schoolId);
+        return ResponseCustom.OK();
+    }
+
+    // 학교 구독 취소
+    @DeleteMapping("/{schoolId}")
+    public ResponseCustom cancel(
+            @Account User user,
+            @PathVariable Long schoolId)
+    {
+        subscribeService.cancel(user, schoolId);
         return ResponseCustom.OK();
     }
 }

--- a/src/main/java/com/example/everyminute/subscribe/dto/response/GetSubscriptionsRes.java
+++ b/src/main/java/com/example/everyminute/subscribe/dto/response/GetSubscriptionsRes.java
@@ -1,0 +1,26 @@
+package com.example.everyminute.subscribe.dto.response;
+
+import com.example.everyminute.subscribe.entity.Subscribe;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class GetSubscriptionsRes {
+
+    @Schema(type = "Long", description = "학교 id", example = "1")
+    private Long schoolId;
+    @Schema(type = "String", description = "학교 이름", example = "명지대학교")
+    private String schoolName;
+    @Schema(type = "String", description = "학교 지역", example = "서울")
+    private String region;
+
+    public static GetSubscriptionsRes toDto(Subscribe subscribe) {
+        return GetSubscriptionsRes.builder()
+                .schoolId(subscribe.getSchool().getSchoolId())
+                .schoolName(subscribe.getSchool().getName())
+                .region(subscribe.getSchool().getRegion())
+                .build();
+    }
+}

--- a/src/main/java/com/example/everyminute/subscribe/entity/Subscribe.java
+++ b/src/main/java/com/example/everyminute/subscribe/entity/Subscribe.java
@@ -39,4 +39,8 @@ public class Subscribe extends BaseEntity {
                 .school(school)
                 .build();
     }
+
+    public void cancel() {
+        this.setIsEnable(false);
+    }
 }

--- a/src/main/java/com/example/everyminute/subscribe/entity/Subscribe.java
+++ b/src/main/java/com/example/everyminute/subscribe/entity/Subscribe.java
@@ -4,6 +4,7 @@ import com.example.everyminute.global.entity.BaseEntity;
 import com.example.everyminute.school.entity.School;
 import com.example.everyminute.user.entity.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,17 @@ public class Subscribe extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "school_id")
     private School school;
+
+    @Builder
+    public Subscribe(User user, School school) {
+        this.user = user;
+        this.school = school;
+    }
+
+    public static Subscribe of(User user, School school) {
+        return Subscribe.builder()
+                .user(user)
+                .school(school)
+                .build();
+    }
 }

--- a/src/main/java/com/example/everyminute/subscribe/repository/SubscribeCustom.java
+++ b/src/main/java/com/example/everyminute/subscribe/repository/SubscribeCustom.java
@@ -1,0 +1,10 @@
+package com.example.everyminute.subscribe.repository;
+
+import com.example.everyminute.subscribe.dto.response.GetSubscriptionsRes;
+import com.example.everyminute.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface SubscribeCustom {
+    Page<GetSubscriptionsRes> getSubscriptionsByUser(User user, Pageable pageable);
+}

--- a/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepository.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long>, SubscribeCustom {
 
     Optional<Subscribe> findByUserAndSchoolAndIsEnable(User user, School school, Boolean isEnable);
+
+    void findByUserAndIsEnable(User user, boolean b);
 }

--- a/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepository.java
@@ -1,9 +1,15 @@
 package com.example.everyminute.subscribe.repository;
 
+import com.example.everyminute.school.entity.School;
 import com.example.everyminute.subscribe.entity.Subscribe;
+import com.example.everyminute.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+
+    Optional<Subscribe> findByUserAndSchoolAndIsEnable(User user, School school, Boolean isEnable);
 }

--- a/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepositoryImpl.java
+++ b/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.example.everyminute.subscribe.repository;
+
+import com.example.everyminute.subscribe.dto.response.GetSubscriptionsRes;
+import com.example.everyminute.subscribe.entity.Subscribe;
+import com.example.everyminute.user.entity.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.example.everyminute.subscribe.entity.QSubscribe.subscribe;
+
+@RequiredArgsConstructor
+public class SubscribeRepositoryImpl implements SubscribeCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<GetSubscriptionsRes> getSubscriptionsByUser(User user, Pageable pageable) {
+        List<Subscribe> subscribes = jpaQueryFactory.selectFrom(subscribe)
+                .where(subscribe.user.eq(user)
+                        .and(subscribe.isEnable.eq(true)))
+                .orderBy(subscribe.createdAt.desc())
+                .fetch();
+
+        List<GetSubscriptionsRes> res = subscribes.stream()
+                .map(GetSubscriptionsRes::toDto)
+                .collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), res.size());
+        return new PageImpl<>(res.subList(start, end), pageable, res.size());
+    }
+}

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -1,0 +1,27 @@
+package com.example.everyminute.subscribe.service;
+
+import com.example.everyminute.global.exception.BaseException;
+import com.example.everyminute.global.exception.BaseResponseCode;
+import com.example.everyminute.school.entity.School;
+import com.example.everyminute.school.repository.SchoolRepository;
+import com.example.everyminute.subscribe.entity.Subscribe;
+import com.example.everyminute.subscribe.repository.SubscribeRepository;
+import com.example.everyminute.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscribeService {
+
+    private final SubscribeRepository subscribeRepository;
+    private final SchoolRepository schoolRepository;
+
+    @Transactional
+    public void subscribeSchool(User user, Long schoolId) {
+        School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
+        subscribeRepository.save(Subscribe.of(user, school));
+    }
+}

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -4,10 +4,13 @@ import com.example.everyminute.global.exception.BaseException;
 import com.example.everyminute.global.exception.BaseResponseCode;
 import com.example.everyminute.school.entity.School;
 import com.example.everyminute.school.repository.SchoolRepository;
+import com.example.everyminute.subscribe.dto.response.GetSubscriptionsRes;
 import com.example.everyminute.subscribe.entity.Subscribe;
 import com.example.everyminute.subscribe.repository.SubscribeRepository;
 import com.example.everyminute.user.entity.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,4 +34,9 @@ public class SubscribeService {
         Subscribe subscribe = subscribeRepository.findByUserAndSchoolAndIsEnable(user, school, true).orElseThrow(() -> new BaseException(BaseResponseCode.SUBSCRIBE_NOT_FOUND));
         subscribe.cancel();
     }
+
+    public Page<GetSubscriptionsRes> getSubscriptions(User user, Pageable pageable) {
+        return subscribeRepository.getSubscriptionsByUser(user, pageable);
+    }
+
 }

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -24,4 +24,11 @@ public class SubscribeService {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
         subscribeRepository.save(Subscribe.of(user, school));
     }
+
+    @Transactional
+    public void cancel(User user, Long schoolId) {
+        School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
+        Subscribe subscribe = subscribeRepository.findByUserAndSchoolAndIsEnable(user, school, true).orElseThrow(() -> new BaseException(BaseResponseCode.SUBSCRIBE_NOT_FOUND));
+        subscribe.cancel();
+    }
 }


### PR DESCRIPTION
## 작업 내용

1. 학교 구독 API
  - DB에 구독할 학교가 없다면 예외발생.
2. 학교 구독 취소 API
  - DB에 구독할 학교가 없다면 예외발생.
  - DB에 구독 내역이 없다면 예외 발생.
3. 학교 구독 목록 조회 API
  - 유저가 구독한 학교 목록을 조회합니다.
  - Page<GetSubscriptionsRes>를 반환하며 DTO는 학교 페이지 접근 편의를 위해 schoold를 포함합니다.
  - 서비스 로직 가독성을 위해 비즈니스 로직은 Repository Layer에 배치해두었습니다.(QueryDSL)
4. 학교 페이지별 소식 조회 API
  - 학교 페이지별 소식 조회 API는 news 도메인 내부에 구현했습니다.
  - API는 Page<SchoolNewsRes>를 반환하며 DTO는 제목, 내용, 작성자, 작성일시를 포함합니다.
  - 서비스 로직 가독성을 위해 비즈니스 로직은 Repository Layer에 배치해두었습니다.(QueryDSL)
## 스크린샷
<img width="1011" alt="스크린샷 2024-03-29 오후 2 29 49" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/a7f8c063-be9c-4236-ac92-1360e65cf433">
<img width="1011" alt="스크린샷 2024-03-29 오후 2 37 48" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/45cc9cf9-b434-4f55-bb1b-d3e756908e3e">
<img width="1040" alt="스크린샷 2024-03-29 오후 3 56 59" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/3322fde6-189b-4070-ac55-0920763efb03">
<img width="1050" alt="스크린샷 2024-03-29 오후 4 41 25" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/0a8a85eb-9d64-4655-9278-4e3f0d49d9e3">
## 💬 기타 사항
- x

Closes #12 