### PR TITLE
[feat] 뉴스피드 API 기능구현

### DIFF
--- a/src/main/java/com/example/everyminute/news/controller/NewsController.java
+++ b/src/main/java/com/example/everyminute/news/controller/NewsController.java
@@ -63,4 +63,17 @@ public class NewsController {
     {
         return ResponseCustom.OK(newsService.getSchoolNews(schoolId, pageable));
     }
+
+    /*
+    - 학생이 구독중인 학교 뉴스피드
+    - 구독 시점부터 최신순으로 노출됨
+    - 구독을 취소해도 기존 뉴스피드에 노출된 소식은 유지
+     */
+    @GetMapping("")
+    public ResponseCustom<Page<SchoolNewsRes>> getSchoolNews(
+            @Account User user,
+            @PageableDefault(size = 20) Pageable pageable)
+    {
+        return ResponseCustom.OK(newsService.getSchoolNews(user, pageable));
+    }
 }

--- a/src/main/java/com/example/everyminute/news/repository/NewsCustom.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsCustom.java
@@ -5,6 +5,10 @@ import com.example.everyminute.school.entity.School;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface NewsCustom {
     Page<SchoolNewsRes> getSchoolNews(School school, Pageable pageable);
+
+    Page<SchoolNewsRes> getSchoolNews(List<School> schools, Pageable pageable);
 }

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
@@ -10,6 +10,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -30,6 +33,28 @@ public class NewsRepositoryImpl implements NewsCustom{
                 .fetch();
 
         List<SchoolNewsRes> res = schoolNews.stream()
+                .map(SchoolNewsRes::toDto).collect(Collectors.toList());
+
+        int start = (int) pageable.getOffset();
+        int end = Math.min((start + pageable.getPageSize()), res.size());
+        return new PageImpl<>(res.subList(start, end), pageable, res.size());
+    }
+
+    @Override
+    public Page<SchoolNewsRes> getSchoolNews(List<School> schools, Pageable pageable) {
+           List<News> subscribeNews =new ArrayList<>();
+
+        for (School school : schools) {
+            subscribeNews.addAll(
+            jpaQueryFactory.selectFrom(news)
+                    .where(news.school.eq(school)
+                            .and(news.isEnable.eq(true)))
+                    .fetch());
+        }
+
+        subscribeNews.sort(Comparator.comparing(News::getCreatedAt).reversed());
+
+        List<SchoolNewsRes> res = subscribeNews.stream()
                 .map(SchoolNewsRes::toDto).collect(Collectors.toList());
 
         int start = (int) pageable.getOffset();

--- a/src/main/java/com/example/everyminute/news/service/NewsService.java
+++ b/src/main/java/com/example/everyminute/news/service/NewsService.java
@@ -71,7 +71,7 @@ public class NewsService {
 
     // 유저가 구독한 학교 페이지 소식 모음
     public Page<SchoolNewsRes> getSchoolNews(User user, Pageable pageable) {
-        List<School> schools = user.getSubscribeList().stream().map(Subscribe::getSchool).collect(Collectors.toList());
+        List<School> schools = user.getSubscribeList().stream().filter(s -> s.getIsEnable().equals(true)).map(Subscribe::getSchool).collect(Collectors.toList());
         return newsRepository.getSchoolNews(schools, pageable);
     }
 }

--- a/src/main/java/com/example/everyminute/news/service/NewsService.java
+++ b/src/main/java/com/example/everyminute/news/service/NewsService.java
@@ -9,6 +9,7 @@ import com.example.everyminute.news.entity.News;
 import com.example.everyminute.news.repository.NewsRepository;
 import com.example.everyminute.school.entity.School;
 import com.example.everyminute.school.repository.SchoolRepository;
+import com.example.everyminute.subscribe.entity.Subscribe;
 import com.example.everyminute.user.entity.Role;
 import com.example.everyminute.user.entity.User;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -59,8 +63,15 @@ public class NewsService {
         if (!user.checkRole(Role.ADMIN)) throw new BaseException(BaseResponseCode.NO_AUTHENTICATION);
     }
 
+    // 학교 페이지 소식 모음
     public Page<SchoolNewsRes> getSchoolNews(Long schoolId, Pageable pageable) {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
         return newsRepository.getSchoolNews(school, pageable);
+    }
+
+    // 유저가 구독한 학교 페이지 소식 모음
+    public Page<SchoolNewsRes> getSchoolNews(User user, Pageable pageable) {
+        List<School> schools = user.getSubscribeList().stream().map(Subscribe::getSchool).collect(Collectors.toList());
+        return newsRepository.getSchoolNews(schools, pageable);
     }
 }

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -34,6 +34,7 @@ public class SubscribeService {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
         Subscribe subscribe = subscribeRepository.findByUserAndSchoolAndIsEnable(user, school, true).orElseThrow(() -> new BaseException(BaseResponseCode.SUBSCRIBE_NOT_FOUND));
         subscribe.cancel();
+        user.cancelSubscribe(subscribe);
     }
 
     public Page<GetSubscriptionsRes> getSubscriptions(User user, Pageable pageable) {

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -22,10 +22,11 @@ public class SubscribeService {
     private final SubscribeRepository subscribeRepository;
     private final SchoolRepository schoolRepository;
 
+    // todo 구독 중복 예외처리
     @Transactional
     public void subscribeSchool(User user, Long schoolId) {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
-        subscribeRepository.save(Subscribe.of(user, school));
+        user.addSubscribe(subscribeRepository.save(Subscribe.of(user, school)));
     }
 
     @Transactional

--- a/src/main/java/com/example/everyminute/user/entity/User.java
+++ b/src/main/java/com/example/everyminute/user/entity/User.java
@@ -1,6 +1,7 @@
 package com.example.everyminute.user.entity;
 
 import com.example.everyminute.global.entity.BaseEntity;
+import com.example.everyminute.subscribe.entity.Subscribe;
 import com.example.everyminute.user.dto.request.JoinReq;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,6 +11,8 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -35,6 +38,9 @@ public class User extends BaseEntity {
     @Size(max = 255)
     private String password;
 
+    @OneToMany(mappedBy = "user")
+    private List<Subscribe> subscribeList = new ArrayList<>();
+
     @Builder
     public User(String name, Role role, String email, String password) {
         this.name = name;
@@ -54,5 +60,9 @@ public class User extends BaseEntity {
 
     public boolean checkRole(Role role) {
         return this.role == role;
+    }
+
+    public void addSubscribe(Subscribe subscribe) {
+        this.subscribeList.add(subscribe);
     }
 }

--- a/src/main/java/com/example/everyminute/user/entity/User.java
+++ b/src/main/java/com/example/everyminute/user/entity/User.java
@@ -65,4 +65,8 @@ public class User extends BaseEntity {
     public void addSubscribe(Subscribe subscribe) {
         this.subscribeList.add(subscribe);
     }
+
+    public void cancelSubscribe(Subscribe subscribe) {
+        this.subscribeList.remove(subscribe);
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 뉴스피드 API 기능구현입니다.
- 서비스 로직 가독성을 위해 비즈니스 로직은 Repository Layer에 배치해두었습니다.(QueryDSL)
## 스크린샷
<img width="1041" alt="스크린샷 2024-03-30 오후 9 00 06" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/13e8e286-02be-4f7c-a2b7-9a41963eb386">
## 💬 기타 사항

- 구독 취소 시 기존 뉴스피드에 있던 소식이 같이 사라지는 증상이 있습니다. 
- 현재 구현 방식 검토중이며, 문제 해결 이후 새로운 PR 업로드 하겠습니다.

Closes #14 