### PR TITLE
[feat] 학교 구독 API 구독 내역 중복 예외처리.

### DIFF
--- a/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
+++ b/src/main/java/com/example/everyminute/global/exception/BaseResponseCode.java
@@ -44,7 +44,8 @@ public enum BaseResponseCode {
     NEWS_NOT_FOUND("N0004", HttpStatus.NOT_FOUND, "존재하지 않는 소식입니다."),
 
     // subscribe : SUCCESS, USER 코드와 중복으로 인해 B000X로 지정함
-    SUBSCRIBE_NOT_FOUND("B0001", HttpStatus.NOT_FOUND, "존재하지 않는 구독 내역입니다.");
+    SUBSCRIBE_NOT_FOUND("B0001", HttpStatus.NOT_FOUND, "존재하지 않는 구독 내역입니다."),
+    ALREADY_SUBSCRIBE_SCHOOL("B0002", HttpStatus.BAD_REQUEST, "이미 구독한 학교입니다.");
 
     public final String code;
     public final HttpStatus status;

--- a/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepository.java
+++ b/src/main/java/com/example/everyminute/subscribe/repository/SubscribeRepository.java
@@ -13,5 +13,5 @@ public interface SubscribeRepository extends JpaRepository<Subscribe, Long>, Sub
 
     Optional<Subscribe> findByUserAndSchoolAndIsEnable(User user, School school, Boolean isEnable);
 
-    void findByUserAndIsEnable(User user, boolean b);
+    Boolean existsByUserAndSchoolAndIsEnable(User user, School school, Boolean isEnable);
 }

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -22,10 +22,10 @@ public class SubscribeService {
     private final SubscribeRepository subscribeRepository;
     private final SchoolRepository schoolRepository;
 
-    // todo 구독 중복 예외처리
     @Transactional
     public void subscribeSchool(User user, Long schoolId) {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
+        if(subscribeRepository.existsByUserAndSchoolAndIsEnable(user, school, true)) throw new BaseException(BaseResponseCode.ALREADY_SUBSCRIBE_SCHOOL);
         user.addSubscribe(subscribeRepository.save(Subscribe.of(user, school)));
     }
 


### PR DESCRIPTION
## 작업 내용
- 학교 구독 내역 중복 예외처리입니다.
- 학생의 학교 구독 목록이 DB에 존재할 때 예외 발생.
## 스크린샷
<img width="1008" alt="스크린샷 2024-03-30 오후 10 13 50" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/3bcd64b2-aeaa-4ec1-8372-a881dcc70bb0">

## 💬 기타 사항
- x

Closes #16 