### PR TITLE
[feat] 뉴스피드 API 소식 유지 기능구현

### DIFF
--- a/src/main/java/com/example/everyminute/global/Constants.java
+++ b/src/main/java/com/example/everyminute/global/Constants.java
@@ -13,6 +13,9 @@ public class Constants {
         public static final String LOGOUT = "logout";
         public static final String SIGNOUT = "signout";
     }
+    public static class REDIS{
+        public static final String FEED_KEY = "userId::";
+    }
 
 
 }

--- a/src/main/java/com/example/everyminute/global/config/RedisConfig.java
+++ b/src/main/java/com/example/everyminute/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.example.everyminute.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Value("${redis.host}")
+    private String host;
+    @Value("${redis.port}")
+    private Integer port;
+    @Value("${redis.password}")
+    private String password;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        redisStandaloneConfiguration.setPassword(password);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/everyminute/global/config/RedisConfig.java
+++ b/src/main/java/com/example/everyminute/global/config/RedisConfig.java
@@ -7,6 +7,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -28,7 +30,11 @@ public class RedisConfig {
 
     @Bean
     public RedisTemplate<?, ?> redisTemplate() {
-        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        RedisTemplate<Object, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashKeySerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
     }

--- a/src/main/java/com/example/everyminute/global/utils/JwtUtil.java
+++ b/src/main/java/com/example/everyminute/global/utils/JwtUtil.java
@@ -80,7 +80,7 @@ public class JwtUtil {
     }
 
     // redis 내 token 가져오기
-    public String getTokenInRedis(String token){
+    public Object getTokenInRedis(String token){
         return redisUtil.getValue(token);
     }
 

--- a/src/main/java/com/example/everyminute/global/utils/RedisUtil.java
+++ b/src/main/java/com/example/everyminute/global/utils/RedisUtil.java
@@ -1,11 +1,15 @@
 package com.example.everyminute.global.utils;
 
+import com.example.everyminute.global.Constants;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -13,7 +17,8 @@ import java.util.concurrent.TimeUnit;
 @RequiredArgsConstructor
 public class RedisUtil {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisTemplate<Object, Object> redisTemplate;
+
     public void setValue(String key, String value, Duration time) {
         redisTemplate.opsForValue().set(key, value, time);
     }
@@ -22,7 +27,14 @@ public class RedisUtil {
         redisTemplate.opsForValue().set(key, value, exp, time);
     }
 
-    public String getValue(String key){
+    @Transactional
+    public void setValue(Long key, List<Long> value) {
+        for (Long l : value) {
+            redisTemplate.opsForList().leftPush(Constants.REDIS.FEED_KEY+key, l);
+        }
+    }
+
+    public Object getValue(String key){
         return redisTemplate.opsForValue().get(key);
     }
 

--- a/src/main/java/com/example/everyminute/global/utils/RedisUtil.java
+++ b/src/main/java/com/example/everyminute/global/utils/RedisUtil.java
@@ -1,15 +1,15 @@
 package com.example.everyminute.global.utils;
 
 import com.example.everyminute.global.Constants;
+import com.example.everyminute.subscribe.entity.Subscribe;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -28,9 +28,19 @@ public class RedisUtil {
     }
 
     @Transactional
-    public void setValue(Long key, List<Long> value) {
+    public void setNewsFeed(Long key, List<Long> value) {
         for (Long l : value) {
-            redisTemplate.opsForList().leftPush(Constants.REDIS.FEED_KEY+key, l);
+            redisTemplate.opsForSet().add(Constants.REDIS.FEED_KEY+key, l);
+        }
+    }
+
+    public Set<Object> getNewsListByUserId(Long key) {
+        return redisTemplate.opsForSet().members(Constants.REDIS.FEED_KEY + key);
+    }
+
+    public void updateNewsFeed(List<Subscribe> subscribeList, Long value) {
+        for (Subscribe subscribe : subscribeList) {
+            redisTemplate.opsForSet().add(Constants.REDIS.FEED_KEY+subscribe.getUser().getUserId(), value);
         }
     }
 

--- a/src/main/java/com/example/everyminute/news/controller/NewsController.java
+++ b/src/main/java/com/example/everyminute/news/controller/NewsController.java
@@ -100,10 +100,10 @@ public class NewsController {
             @ApiResponse(responseCode = "200", description = "(S0001) 조회 성공"),
     })
     @GetMapping("")
-    public ResponseCustom<Page<SchoolNewsRes>> getSchoolNews(
+    public ResponseCustom<Page<SchoolNewsRes>> getNewsFeed(
             @Account User user,
             @PageableDefault(size = 20) Pageable pageable)
     {
-        return ResponseCustom.OK(newsService.getSchoolNews(user, pageable));
+        return ResponseCustom.OK(newsService.getNewsFeed(user, pageable));
     }
 }

--- a/src/main/java/com/example/everyminute/news/repository/NewsCustom.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsCustom.java
@@ -6,9 +6,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Set;
 
 public interface NewsCustom {
     Page<SchoolNewsRes> getSchoolNews(School school, Pageable pageable);
 
-    Page<SchoolNewsRes> getSchoolNews(List<School> schools, Pageable pageable);
+    Page<SchoolNewsRes> getNewsFeed(Set<Object> list, Pageable pageable);
 }

--- a/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
+++ b/src/main/java/com/example/everyminute/news/repository/NewsRepositoryImpl.java
@@ -10,11 +10,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.example.everyminute.news.entity.QNews.news;
 
@@ -41,20 +39,18 @@ public class NewsRepositoryImpl implements NewsCustom{
     }
 
     @Override
-    public Page<SchoolNewsRes> getSchoolNews(List<School> schools, Pageable pageable) {
-           List<News> subscribeNews =new ArrayList<>();
+    public Page<SchoolNewsRes> getNewsFeed(Set<Object> list, Pageable pageable) {
 
-        for (School school : schools) {
-            subscribeNews.addAll(
-            jpaQueryFactory.selectFrom(news)
-                    .where(news.school.eq(school)
+        List<News> feed = list.stream().map(m -> {
+            return jpaQueryFactory.selectFrom(news)
+                    .where(news.newsId.eq(Long.valueOf(m.toString()))
                             .and(news.isEnable.eq(true)))
-                    .fetch());
-        }
+                    .fetchOne();
+        }).collect(Collectors.toList());
 
-        subscribeNews.sort(Comparator.comparing(News::getCreatedAt).reversed());
+        feed.sort(Comparator.comparing(News::getCreatedAt).reversed());
 
-        List<SchoolNewsRes> res = subscribeNews.stream()
+        List<SchoolNewsRes> res = feed.stream()
                 .map(SchoolNewsRes::toDto).collect(Collectors.toList());
 
         int start = (int) pageable.getOffset();

--- a/src/main/java/com/example/everyminute/school/entity/School.java
+++ b/src/main/java/com/example/everyminute/school/entity/School.java
@@ -3,6 +3,7 @@ package com.example.everyminute.school.entity;
 import com.example.everyminute.global.entity.BaseEntity;
 import com.example.everyminute.news.entity.News;
 import com.example.everyminute.school.dto.request.RegisterSchoolReq;
+import com.example.everyminute.subscribe.entity.Subscribe;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +34,9 @@ public class School extends BaseEntity {
 
     @OneToMany(mappedBy = "school")
     private List<News> newsList = new ArrayList<News>();
+
+    @OneToMany(mappedBy = "school")
+    private List<Subscribe> subscribeList = new ArrayList<>();
 
     @Builder
     public School(String name, String region) {

--- a/src/main/java/com/example/everyminute/school/entity/School.java
+++ b/src/main/java/com/example/everyminute/school/entity/School.java
@@ -58,4 +58,8 @@ public class School extends BaseEntity {
     public void removeNews(News news) {
         this.newsList.remove(news);
     }
+
+    public void cancelSubscribe(Subscribe subscribe) {
+        this.subscribeList.remove(subscribe);
+    }
 }

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -34,7 +34,7 @@ public class SubscribeService {
         if(subscribeRepository.existsByUserAndSchoolAndIsEnable(user, school, true)) throw new BaseException(BaseResponseCode.ALREADY_SUBSCRIBE_SCHOOL);
         List<Long> newsIdList = school.getNewsList().stream().map(News::getNewsId).collect(Collectors.toList());
         // 유저별 뉴스피드 목록 redis 저장
-        redisUtil.setValue(user.getUserId(), newsIdList);
+        redisUtil.setNewsFeed(user.getUserId(), newsIdList);
         user.addSubscribe(subscribeRepository.save(Subscribe.of(user, school)));
     }
 
@@ -42,8 +42,9 @@ public class SubscribeService {
     public void cancel(User user, Long schoolId) {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
         Subscribe subscribe = subscribeRepository.findByUserAndSchoolAndIsEnable(user, school, true).orElseThrow(() -> new BaseException(BaseResponseCode.SUBSCRIBE_NOT_FOUND));
-        subscribe.cancel();
         user.cancelSubscribe(subscribe);
+        school.cancelSubscribe(subscribe);
+        subscribeRepository.delete(subscribe);
     }
 
     public Page<GetSubscriptionsRes> getSubscriptions(User user, Pageable pageable) {

--- a/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
+++ b/src/main/java/com/example/everyminute/subscribe/service/SubscribeService.java
@@ -2,6 +2,8 @@ package com.example.everyminute.subscribe.service;
 
 import com.example.everyminute.global.exception.BaseException;
 import com.example.everyminute.global.exception.BaseResponseCode;
+import com.example.everyminute.global.utils.RedisUtil;
+import com.example.everyminute.news.entity.News;
 import com.example.everyminute.school.entity.School;
 import com.example.everyminute.school.repository.SchoolRepository;
 import com.example.everyminute.subscribe.dto.response.GetSubscriptionsRes;
@@ -14,6 +16,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -21,11 +26,15 @@ public class SubscribeService {
 
     private final SubscribeRepository subscribeRepository;
     private final SchoolRepository schoolRepository;
+    private final RedisUtil redisUtil;
 
     @Transactional
     public void subscribeSchool(User user, Long schoolId) {
         School school = schoolRepository.findBySchoolIdAndIsEnable(schoolId, true).orElseThrow(() -> new BaseException(BaseResponseCode.SCHOOL_NOT_FOUNT));
         if(subscribeRepository.existsByUserAndSchoolAndIsEnable(user, school, true)) throw new BaseException(BaseResponseCode.ALREADY_SUBSCRIBE_SCHOOL);
+        List<Long> newsIdList = school.getNewsList().stream().map(News::getNewsId).collect(Collectors.toList());
+        // 유저별 뉴스피드 목록 redis 저장
+        redisUtil.setValue(user.getUserId(), newsIdList);
         user.addSubscribe(subscribeRepository.save(Subscribe.of(user, school)));
     }
 


### PR DESCRIPTION
## 작업 내용
- redis config 설정 (피드 DB 운용)
- 소식 게시 API 호출 시점 피드 피드 DB 업데이트 기능 추가
- 학교 구독 API 호출 시점 피드 피드 DB 업데이트 기능 추가
- 피드 DB 호출로 뉴스피드 API 소식 유지 기능 구현 (구독을 취소해도 기존 피드에 나타난 소식은 유지되어야함)
## 스크린샷
<img width="1006" alt="스크린샷 2024-03-31 오후 6 00 40" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/d475f7ac-11f3-4138-a47a-16a864c35ff4">

## 💬 기타 사항
- 유저 구독 취소후 다시 구독했을 때 피드 DB에 소식id 중복 현상이 있었습니다.
- 현재 redis opsForSet 구현으로 소식 유지기능 정상적으로 작동중입니다.
- 유저별 피드 선별 로직 개선 후 refactor PR 업로드 예정입니다.

Closes #20 