### PR TITLE
[test] 유저 API 테스트 코드 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
 }
 
-tasks.named('test') {
+test {
 	useJUnitPlatform()
 }
 

--- a/src/main/java/com/example/everyminute/user/dto/request/JoinReq.java
+++ b/src/main/java/com/example/everyminute/user/dto/request/JoinReq.java
@@ -2,6 +2,7 @@ package com.example.everyminute.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import javax.validation.constraints.Pattern;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 public class JoinReq {
 
     @Schema(type = "String", description = "성명", example = "홍길동", required = true)

--- a/src/main/java/com/example/everyminute/user/dto/request/LoginReq.java
+++ b/src/main/java/com/example/everyminute/user/dto/request/LoginReq.java
@@ -1,6 +1,7 @@
 package com.example.everyminute.user.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
 import lombok.Getter;
 
 import javax.validation.constraints.Email;
@@ -8,6 +9,7 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
 
 @Getter
+@Builder
 public class LoginReq {
 
     @Schema(type = "String", description = "이메일", example = "1234@email.com", required = true)

--- a/src/main/java/com/example/everyminute/user/entity/User.java
+++ b/src/main/java/com/example/everyminute/user/entity/User.java
@@ -42,7 +42,8 @@ public class User extends BaseEntity {
     private List<Subscribe> subscribeList = new ArrayList<>();
 
     @Builder
-    public User(String name, Role role, String email, String password) {
+    public User(Long userId, String name, Role role, String email, String password) {
+        this.userId = userId;
         this.name = name;
         this.role = role;
         this.email = email;

--- a/src/test/java/com/example/everyminute/global/ControllerTestSupport.java
+++ b/src/test/java/com/example/everyminute/global/ControllerTestSupport.java
@@ -1,0 +1,41 @@
+package com.example.everyminute.global;
+
+
+import com.example.everyminute.global.resolver.LoginResolver;
+import com.example.everyminute.global.utils.JwtUtil;
+import com.example.everyminute.news.controller.NewsController;
+import com.example.everyminute.news.service.NewsService;
+import com.example.everyminute.school.controller.SchoolController;
+import com.example.everyminute.school.service.SchoolService;
+import com.example.everyminute.subscribe.controller.SubscribeController;
+import com.example.everyminute.subscribe.service.SubscribeService;
+import com.example.everyminute.user.controller.UserController;
+import com.example.everyminute.user.entity.User;
+import com.example.everyminute.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = {
+                UserController.class,
+                SchoolController.class,
+                SubscribeController.class,
+                NewsController.class,
+        }
+)
+@MockBean(JpaMetamodelMappingContext.class)
+public abstract class ControllerTestSupport {
+    @Autowired protected MockMvc mockMvc;
+    @Autowired protected ObjectMapper objectMapper;
+    @MockBean protected LoginResolver loginResolver;
+    @MockBean protected JwtUtil jwtUtil;
+    @MockBean protected User user;
+    @MockBean protected UserService userService;
+    @MockBean protected SchoolService schoolService;
+    @MockBean protected SubscribeService subscribeService;
+    @MockBean protected NewsService newsService;
+}

--- a/src/test/java/com/example/everyminute/global/IntegrationTestSupport.java
+++ b/src/test/java/com/example/everyminute/global/IntegrationTestSupport.java
@@ -1,0 +1,13 @@
+package com.example.everyminute.global;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@Rollback
+public abstract class IntegrationTestSupport {
+}

--- a/src/test/java/com/example/everyminute/user/controller/UserControllerTest.java
+++ b/src/test/java/com/example/everyminute/user/controller/UserControllerTest.java
@@ -1,0 +1,5 @@
+package com.example.everyminute.user.controller;
+
+
+public class UserControllerTest {
+}

--- a/src/test/java/com/example/everyminute/user/dto/TestUserDto.java
+++ b/src/test/java/com/example/everyminute/user/dto/TestUserDto.java
@@ -17,6 +17,15 @@ public class TestUserDto {
                 .build();
     }
 
+    public static JoinReq setUpJoinReq(String email, String pw){
+        return JoinReq.builder()
+                .email(email)
+                .password(pw)
+                .name("홍길동")
+                .role("관리자")
+                .build();
+    }
+
     public static User setUpUser(Long userId, Role role, String pw){
         return User.builder()
                 .userId(userId)

--- a/src/test/java/com/example/everyminute/user/dto/TestUserDto.java
+++ b/src/test/java/com/example/everyminute/user/dto/TestUserDto.java
@@ -1,0 +1,29 @@
+package com.example.everyminute.user.dto;
+
+import com.example.everyminute.user.dto.request.JoinReq;
+import com.example.everyminute.user.dto.request.LoginReq;
+import com.example.everyminute.user.entity.Role;
+import com.example.everyminute.user.entity.User;
+
+public class TestUserDto {
+
+    public static final String PASSWORD = "test";
+
+
+    public static LoginReq setUpLoginReq(String email, String pw){
+        return LoginReq.builder()
+                .email(email)
+                .password(pw)
+                .build();
+    }
+
+    public static User setUpUser(Long userId, Role role, String pw){
+        return User.builder()
+                .userId(userId)
+                .name("홍길동")
+                .email("test@email.com")
+                .password(pw)
+                .role(role)
+                .build();
+    }
+}

--- a/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
@@ -95,4 +95,21 @@ public class UserServiceTest {
         verify(passwordEncoder, times(2)).encode(any(String.class));
         verify(userRepository, times(1)).save(any(User.class));
     }
+
+    @Test
+    @DisplayName("[실패] 회원가입 - 존재하는 이메일이 있을경우")
+    void joinFail() {
+        // given
+        User user = setUpUser(1L, Role.ADMIN, passwordEncoder.encode(PASSWORD));
+        JoinReq req = setUpJoinReq("test@email.com", "test");
+
+        // when
+        doReturn(true).when(userRepository).existsByEmailAndIsEnable(req.getEmail(), true);
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            userService.join(req);
+        });
+
+        // then
+        assertThat(exception.getBaseResponseCode()).isEqualTo(BaseResponseCode.ALREADY_USED_EMAIL);
+    }
 }

--- a/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
@@ -64,4 +64,18 @@ public class UserServiceTest {
         verify(jwtUtil, times(1)).createToken(any(Long.class), any(Role.class));
         verify(passwordEncoder, times(1)).encode(any(String.class));
     }
+
+    @Test
+    @DisplayName("[실패] 로그인")
+    void loginFail(){
+        // given
+        LoginReq req = setUpLoginReq("test1@email.com", "test");
+        // when
+        doThrow(new BaseException(BaseResponseCode.USER_NOT_FOUND)).when(userRepository).findByEmailAndIsEnable(req.getEmail(), true);
+        // then
+        BaseException exception = assertThrows(BaseException.class, () -> {
+            userService.login(req);
+        });
+        assertThat(exception.getBaseResponseCode()).isEqualTo(BaseResponseCode.USER_NOT_FOUND);
+    }
 }

--- a/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
@@ -78,4 +78,21 @@ public class UserServiceTest {
         });
         assertThat(exception.getBaseResponseCode()).isEqualTo(BaseResponseCode.USER_NOT_FOUND);
     }
+
+    @Test
+    @DisplayName("[성공] 회원가입")
+    void join() {
+        // given
+        User user = setUpUser(1L, Role.ADMIN, passwordEncoder.encode(PASSWORD));
+        JoinReq req = setUpJoinReq("test@email.com", "test");
+
+        // when
+        when(userRepository.save(any(User.class))).then(AdditionalAnswers.returnsFirstArg());
+        userService.join(req);
+
+        // verify - because of void method
+        verify(userRepository, times(1)).existsByEmailAndIsEnable(any(String.class), any(Boolean.class));
+        verify(passwordEncoder, times(2)).encode(any(String.class));
+        verify(userRepository, times(1)).save(any(User.class));
+    }
 }

--- a/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
+++ b/src/test/java/com/example/everyminute/user/service/UserServiceTest.java
@@ -1,0 +1,67 @@
+package com.example.everyminute.user.service;
+
+import com.example.everyminute.global.exception.BaseException;
+import com.example.everyminute.global.exception.BaseResponseCode;
+import com.example.everyminute.global.utils.JwtUtil;
+import com.example.everyminute.user.dto.TokenDto;
+import com.example.everyminute.user.dto.request.JoinReq;
+import com.example.everyminute.user.dto.request.LoginReq;
+import com.example.everyminute.user.entity.Role;
+import com.example.everyminute.user.entity.User;
+import com.example.everyminute.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.AdditionalAnswers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static com.example.everyminute.user.dto.TestUserDto.*;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+
+@ExtendWith(MockitoExtension.class)
+public class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    JwtUtil jwtUtil;
+    @Spy
+    BCryptPasswordEncoder passwordEncoder;
+
+    @Test
+    @DisplayName("[성공] 로그인")
+    void login(){
+        // given
+        User user = setUpUser(1L, Role.ADMIN, passwordEncoder.encode(PASSWORD));
+        LoginReq req = setUpLoginReq("test@email.com", "test");
+
+        // when
+        // stub 생성
+        doReturn(Optional.of(user)).when(userRepository).findByEmailAndIsEnable(req.getEmail(), true);
+        when(jwtUtil.createToken(user.getUserId(), user.getRole())).thenReturn(TokenDto.toDto("accessToken", "refreshToken", user.getRole()));
+        TokenDto dto = userService.login(req);
+
+        // then
+        assertThat(req.getEmail()).isEqualTo(user.getEmail());
+        assertThat(passwordEncoder.matches(req.getPassword(), user.getPassword())).isTrue();
+        assertThat(dto.getAccessToken()).isEqualTo("accessToken");
+        assertThat(dto.getRefreshToken()).isEqualTo("refreshToken");
+
+        // verify
+        verify(userRepository, times(1)).findByEmailAndIsEnable(any(String.class), any(Boolean.class));
+        verify(jwtUtil, times(1)).createToken(any(Long.class), any(Role.class));
+        verify(passwordEncoder, times(1)).encode(any(String.class));
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 테스트 코드 초기 구축 (ControllerTestSupport, IntegrationTestSupport)
- 로그인 API 성공, 실패 케이스 구현
- 회원가입 API 성공, 실패(존재하는 이메일이 있을경우) 케이스 구현
## 스크린샷
<img width="1406" alt="스크린샷 2024-04-01 오전 2 39 57" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/eb255e10-f7a1-438b-aeb5-1928e5cbbcb6">

## 💬 기타 사항
- x

Closes #24 