### PR TITLE
[setting] ec2 배포 실행시 ContextLoad() FAILED 에러 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ dependencies {
 	implementation "com.querydsl:querydsl-core:${queryDslVersion}"
 }
 
-test {
+tasks.named('test') {
 	useJUnitPlatform()
 }
 


### PR DESCRIPTION
## 작업 내용
- ec2에서 어플리케이션 테스트 빌드시 다음과 같은 에러 발생했습니다.
- 테스트 코드에서 해당 빈들을 의존성 주입을 해주면서 해결했습니다.
## 스크린샷
<img width="1058" alt="스크린샷 2024-04-01 오후 5 01 55" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/c5b98a96-5d1c-4076-8036-def453788e9f">

## 💬 기타 사항
- x