### PR TITLE
[docs] Swagger ErrorList 명시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 group = 'jpabook '
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = "15"
+sourceCompatibility = "17"
 
 configurations {
 	compileOnly {
@@ -95,4 +95,4 @@ configurations {
 	}
 	querydsl.extendsFrom compileClasspath
 }
-targetCompatibility = JavaVersion.VERSION_15
+targetCompatibility = JavaVersion.VERSION_17

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ plugins {
 
 group = 'jpabook '
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = "15"
 
 configurations {
 	compileOnly {
@@ -95,3 +95,4 @@ configurations {
 	}
 	querydsl.extendsFrom compileClasspath
 }
+targetCompatibility = JavaVersion.VERSION_15

--- a/src/main/java/com/example/everyminute/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/everyminute/global/config/SwaggerConfig.java
@@ -61,7 +61,7 @@ public class SwaggerConfig {
         return new ApiInfoBuilder()
                 .title(API_NAME)
                 .version(API_VERSION)
-                .description(API_DESCRIPTION)
+                .description(getApiDescription(getErrorList()))
                 .build();
     }
 
@@ -91,5 +91,30 @@ public class SwaggerConfig {
             errorList.append("</tr>");
         }
         return errorList.toString();
+    }
+
+    public String getApiDescription(String errorList) {
+        String description = """
+                    Everyminute API 명세서입니다.<br>
+                    스웨거 한계로 인해 Response에 공통 response의 data에 대한 정의가 되어있습니다. <br>
+                    <details>
+                        <summary> ERROR LIST </summary>
+                        <table>
+                            <thead>
+                            <tr>
+                                <th>ERROR CODE</th>
+                                <th>STATUS</th>
+                                <th>ERROR MESSAGE</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                                """
+                + errorList
+                + """
+                                    </tbody>
+                                <table>
+                            </details>
+                            """;
+        return description;
     }
 }


### PR DESCRIPTION
## 작업 내용
- 스웨거의 한계로 Response에 공통 Response data에 대한 정의가 있습니다.
- 에러 응답 가독성을 위한 ErrorList 구현입니다.
## 스크린샷
<img width="1416" alt="스크린샷 2024-04-02 오후 6 10 10" src="https://github.com/dangnak2/EveryMinute_Server/assets/80161984/9c1d2872-6bf9-4cd6-b1ff-0773f642c7e3">

## 💬 기타 사항
- x